### PR TITLE
[Feat/#13] SNS 관련 로직 구현

### DIFF
--- a/src/main/java/com/sopt/push/common/Constants.java
+++ b/src/main/java/com/sopt/push/common/Constants.java
@@ -8,11 +8,11 @@ public class Constants {
 
   public static final String DEFAULT = "default";
 
-    public static final String DELIMITER = "#";
+  public static final String DELIMITER = "#";
   public static final String USER_PREFIX = "u#";
   public static final String TOKEN_PREFIX = "d#";
   public static final String HISTORY_PREFIX = "h#";
-    public static final String YEAR_MONTH_FORMAT = "%04d-%02d";
+  public static final String YEAR_MONTH_FORMAT = "%04d-%02d";
 
   public static final String USER_ENTITY = "user";
   public static final String DEVICE_TOKEN_ENTITY = "deviceToken";
@@ -27,5 +27,5 @@ public class Constants {
   public static final String DEFAULT_MESSAGE = "";
 
   public static final String UNKNOWN_USER = "unknown";
-    public static final String APPLICATION_PROTOCOL = "application";
+  public static final String APPLICATION_PROTOCOL = "application";
 }

--- a/src/main/java/com/sopt/push/common/Constants.java
+++ b/src/main/java/com/sopt/push/common/Constants.java
@@ -23,4 +23,8 @@ public class Constants {
   public static final String APNS = "APNS";
 
   public static final String DEFAULT_MESSAGE = "";
+
+  public static final String DELIMITER = "#";
+
+  public static final String YEAR_MONTH_FORMAT = "%04d-%02d";
 }

--- a/src/main/java/com/sopt/push/common/Constants.java
+++ b/src/main/java/com/sopt/push/common/Constants.java
@@ -27,4 +27,6 @@ public class Constants {
   public static final String DELIMITER = "#";
 
   public static final String YEAR_MONTH_FORMAT = "%04d-%02d";
+
+  public static final String UNKNOWN_USER = "unknown";
 }

--- a/src/main/java/com/sopt/push/common/Constants.java
+++ b/src/main/java/com/sopt/push/common/Constants.java
@@ -8,9 +8,11 @@ public class Constants {
 
   public static final String DEFAULT = "default";
 
+    public static final String DELIMITER = "#";
   public static final String USER_PREFIX = "u#";
   public static final String TOKEN_PREFIX = "d#";
   public static final String HISTORY_PREFIX = "h#";
+    public static final String YEAR_MONTH_FORMAT = "%04d-%02d";
 
   public static final String USER_ENTITY = "user";
   public static final String DEVICE_TOKEN_ENTITY = "deviceToken";
@@ -24,9 +26,6 @@ public class Constants {
 
   public static final String DEFAULT_MESSAGE = "";
 
-  public static final String DELIMITER = "#";
-
-  public static final String YEAR_MONTH_FORMAT = "%04d-%02d";
-
   public static final String UNKNOWN_USER = "unknown";
+    public static final String APPLICATION_PROTOCOL = "application";
 }

--- a/src/main/java/com/sopt/push/common/ExternalException.java
+++ b/src/main/java/com/sopt/push/common/ExternalException.java
@@ -1,0 +1,18 @@
+package com.sopt.push.common;
+
+/**
+ * 비즈니스 규칙 위반이 아닌, 외부 시스템/인프라(SNS 등) 연동 과정에서 발생하는 예외를 나타냅니다.
+ * 주로 5xx 계열 응답으로 매핑되는 시스템 오류에 사용합니다.
+ */
+public class ExternalException extends RuntimeException {
+
+  public ExternalException(String message) {
+    super(message);
+  }
+
+  public ExternalException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}
+
+

--- a/src/main/java/com/sopt/push/common/ExternalException.java
+++ b/src/main/java/com/sopt/push/common/ExternalException.java
@@ -1,6 +1,5 @@
 package com.sopt.push.common;
 
-/** 비즈니스 규칙 위반이 아닌, 외부 시스템/인프라(SNS 등) 연동 과정에서 발생하는 예외를 나타냅니다. 주로 5xx 계열 응답으로 매핑되는 시스템 오류에 사용합니다. */
 public class ExternalException extends RuntimeException {
 
   public ExternalException(String message) {

--- a/src/main/java/com/sopt/push/common/ExternalException.java
+++ b/src/main/java/com/sopt/push/common/ExternalException.java
@@ -1,9 +1,6 @@
 package com.sopt.push.common;
 
-/**
- * 비즈니스 규칙 위반이 아닌, 외부 시스템/인프라(SNS 등) 연동 과정에서 발생하는 예외를 나타냅니다.
- * 주로 5xx 계열 응답으로 매핑되는 시스템 오류에 사용합니다.
- */
+/** 비즈니스 규칙 위반이 아닌, 외부 시스템/인프라(SNS 등) 연동 과정에서 발생하는 예외를 나타냅니다. 주로 5xx 계열 응답으로 매핑되는 시스템 오류에 사용합니다. */
 public class ExternalException extends RuntimeException {
 
   public ExternalException(String message) {
@@ -14,5 +11,3 @@ public class ExternalException extends RuntimeException {
     super(message, cause);
   }
 }
-
-

--- a/src/main/java/com/sopt/push/config/EnvConfig.java
+++ b/src/main/java/com/sopt/push/config/EnvConfig.java
@@ -7,13 +7,19 @@ public final class EnvConfig {
 
   private static final String DYNAMODB_TABLE_ENV_VAR = "DYNAMODB_TABLE";
   private static final String ALL_TOPIC_ARN_ENV_VAR = "ALL_TOPIC_ARN";
+  private static final String PLATFORM_APPLICATION_IOS_ENV_VAR = "PLATFORM_APPLICATION_iOS";
+  private static final String PLATFORM_APPLICATION_ANDROID_ENV_VAR = "PLATFORM_APPLICATION_ANDROID";
 
   private final String dynamoDbTableName;
   private final String allTopicArn;
+  private final String platformApplicationIosArn;
+  private final String platformApplicationAndroidArn;
 
   public EnvConfig() {
     this.dynamoDbTableName = getRequiredEnv(DYNAMODB_TABLE_ENV_VAR);
     this.allTopicArn = getRequiredEnv(ALL_TOPIC_ARN_ENV_VAR);
+    this.platformApplicationIosArn = getRequiredEnv(PLATFORM_APPLICATION_IOS_ENV_VAR);
+    this.platformApplicationAndroidArn = getRequiredEnv(PLATFORM_APPLICATION_ANDROID_ENV_VAR);
   }
 
   private static String getRequiredEnv(String key) {

--- a/src/main/java/com/sopt/push/dto/PushMessagePayloadDto.java
+++ b/src/main/java/com/sopt/push/dto/PushMessagePayloadDto.java
@@ -1,0 +1,7 @@
+package com.sopt.push.dto;
+
+import com.sopt.push.enums.Category;
+
+/** 푸시 메시지 내용(타이틀, 본문, 링크 등)을 표현하는 내부용 DTO 입니다. NotificationService와 상위 레이어 간의 데이터 전달에 사용합니다. */
+public record PushMessagePayloadDto(
+    String id, String title, String content, Category category, String deepLink, String webLink) {}

--- a/src/main/java/com/sopt/push/dto/ResponsePushNotificationDto.java
+++ b/src/main/java/com/sopt/push/dto/ResponsePushNotificationDto.java
@@ -1,0 +1,4 @@
+package com.sopt.push.dto;
+
+/** SNS 발송 후 반환되는 MessageId 를 담는 응답 DTO 입니다. */
+public record ResponsePushNotificationDto(String messageId) {}

--- a/src/main/java/com/sopt/push/lambda/SnsHandler.java
+++ b/src/main/java/com/sopt/push/lambda/SnsHandler.java
@@ -14,6 +14,7 @@ import com.sopt.push.domain.HistoryEntity;
 import com.sopt.push.enums.NotificationStatus;
 import com.sopt.push.repository.DeviceTokenRepository;
 import com.sopt.push.repository.HistoryRepository;
+import com.sopt.push.repository.UserRepository;
 import com.sopt.push.service.SnsService;
 import com.sopt.push.service.UserService;
 import java.time.Instant;
@@ -42,10 +43,12 @@ public class SnsHandler implements RequestHandler<SNSEvent, Void> {
     DynamoDbEnhancedClient enhancedClient = DynamoDbClientProvider.getClient();
     this.deviceTokenRepository =
         new DeviceTokenRepository(enhancedClient, envConfig.getDynamoDbTableName());
+    UserRepository userRepository =
+        new UserRepository(enhancedClient, envConfig.getDynamoDbTableName());
     this.historyRepository =
         new HistoryRepository(enhancedClient, envConfig.getDynamoDbTableName());
     SnsService snsService = new SnsService(envConfig);
-    this.userService = new UserService(deviceTokenRepository, snsService);
+    this.userService = new UserService(deviceTokenRepository, userRepository, snsService);
     this.objectMapper = ObjectMapperConfig.getObjectMapper();
   }
 

--- a/src/main/java/com/sopt/push/lambda/SnsHandler.java
+++ b/src/main/java/com/sopt/push/lambda/SnsHandler.java
@@ -1,5 +1,175 @@
 package com.sopt.push.lambda;
 
-public class SnsHandler {
-  // TODO: Implement SNS handler
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.push.client.DynamoDbClientProvider;
+import com.sopt.push.common.Constants;
+import com.sopt.push.config.EnvConfig;
+import com.sopt.push.config.ObjectMapperConfig;
+import com.sopt.push.domain.DeviceTokenEntity;
+import com.sopt.push.domain.HistoryEntity;
+import com.sopt.push.enums.NotificationStatus;
+import com.sopt.push.repository.DeviceTokenRepository;
+import com.sopt.push.repository.HistoryRepository;
+import com.sopt.push.service.SnsService;
+import com.sopt.push.service.UserService;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+
+@Slf4j
+public class SnsHandler implements RequestHandler<SNSEvent, Void> {
+
+  private static final int SPLIT_LIMIT_FOR_USER_ID_EXTRACTION = 2;
+  private static final int USER_ID_INDEX_IN_SPLIT_PARTS = 1;
+
+  private final EnvConfig envConfig;
+  private final DeviceTokenRepository deviceTokenRepository;
+  private final HistoryRepository historyRepository;
+  private final UserService userService;
+  private final ObjectMapper objectMapper;
+
+  public SnsHandler() {
+    this.envConfig = new EnvConfig();
+    DynamoDbEnhancedClient enhancedClient = DynamoDbClientProvider.getClient();
+    this.deviceTokenRepository =
+        new DeviceTokenRepository(enhancedClient, envConfig.getDynamoDbTableName());
+    this.historyRepository =
+        new HistoryRepository(enhancedClient, envConfig.getDynamoDbTableName());
+    SnsService snsService = new SnsService(envConfig);
+    this.userService = new UserService(deviceTokenRepository, snsService);
+    this.objectMapper = ObjectMapperConfig.getObjectMapper();
+  }
+
+  @Override
+  public Void handleRequest(SNSEvent event, Context context) {
+    boolean invalidEvent = event == null || event.getRecords() == null || event.getRecords().isEmpty();
+    if (invalidEvent) {
+      log.warn("SNS event is null or has no records");
+      return null;
+    }
+
+    Map<String, DeviceTokenEntity> tokenToEntity = collectTokenEntities(event.getRecords());
+    processFailureRecords(event.getRecords(), tokenToEntity);
+    return null;
+  }
+
+  private Map<String, DeviceTokenEntity> collectTokenEntities(
+      java.util.List<SNSEvent.SNSRecord> records) {
+    Map<String, DeviceTokenEntity> tokenToEntity = new HashMap<>();
+    for (SNSEvent.SNSRecord record : records) {
+      String token = extractTokenFromRecord(record);
+      boolean invalidToken = token == null || token.isBlank();
+      if (invalidToken) {
+        log.warn("SNS record does not contain a valid token: {}", record);
+        continue;
+      }
+
+      String pk = Constants.TOKEN_PREFIX + token;
+      Optional<DeviceTokenEntity> entityOptional = deviceTokenRepository.findByPk(pk);
+      entityOptional.ifPresent(entity -> tokenToEntity.put(token, entity));
+    }
+    return tokenToEntity;
+  }
+
+  private void processFailureRecords(
+          List<SNSEvent.SNSRecord> records, Map<String, DeviceTokenEntity> tokenToEntity) {
+    for (SNSEvent.SNSRecord record : records) {
+      String token = extractTokenFromRecord(record);
+      boolean invalidToken = token == null || token.isBlank();
+      if (invalidToken) {
+        continue;
+      }
+
+      DeviceTokenEntity deviceTokenEntity = tokenToEntity.get(token);
+      boolean entityNotFound = deviceTokenEntity == null;
+      if (entityNotFound) {
+        log.warn("No DeviceTokenEntity found for token: {}", token);
+        continue;
+      }
+
+      String messageId = record.getSNS().getMessageId();
+      boolean invalidMessageId = messageId == null || messageId.isBlank();
+      if (invalidMessageId) {
+        log.warn("SNS record does not contain a messageId: {}", record);
+      }
+
+      String userId = extractUserIdFromDeviceTokenEntity(deviceTokenEntity);
+      boolean invalidUserId = userId == null || userId.isBlank();
+      if (invalidUserId) {
+        log.warn("Unable to extract userId from DeviceTokenEntity: {}", deviceTokenEntity);
+      }
+
+      createFailureHistory(userId, messageId);
+      userService.unregisterToken(deviceTokenEntity);
+    }
+  }
+
+  private String extractTokenFromRecord(SNSEvent.SNSRecord record) {
+    try {
+      String message = record.getSNS().getMessage();
+      boolean invalidMessage = message == null || message.isBlank();
+      if (invalidMessage) {
+        return null;
+      }
+      JsonNode root = objectMapper.readTree(message);
+      JsonNode tokenNode = root.path("Token");
+      boolean missingOrBlankToken = tokenNode.isMissingNode() || tokenNode.asText().isBlank();
+      if (missingOrBlankToken) {
+        return null;
+      }
+      return tokenNode.asText();
+    } catch (Exception e) {
+      log.error("Failed to extract token from SNS record message", e);
+      return null;
+    }
+  }
+
+  private String extractUserIdFromDeviceTokenEntity(DeviceTokenEntity entity) {
+    String sk = entity.getSk();
+    boolean invalidSk = sk == null || !sk.contains(Constants.DELIMITER);
+    if (invalidSk) {
+      return null;
+    }
+
+    String[] parts = sk.split(Constants.DELIMITER, SPLIT_LIMIT_FOR_USER_ID_EXTRACTION);
+    boolean validParts = parts.length == SPLIT_LIMIT_FOR_USER_ID_EXTRACTION;
+    return validParts ? parts[USER_ID_INDEX_IN_SPLIT_PARTS] : null;
+  }
+
+  private void createFailureHistory(String userId, String messageId) {
+    ZonedDateTime now = ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
+    String yearMonth = String.format(Constants.YEAR_MONTH_FORMAT, now.getYear(), now.getMonthValue());
+    String timestamp = DateTimeFormatter.ISO_INSTANT.format(now.toInstant());
+    String transactionId = UUID.randomUUID().toString();
+    HistoryEntity history = new HistoryEntity();
+    history.setPk(Constants.HISTORY_PREFIX + yearMonth);
+    history.setSk(Constants.HISTORY_PREFIX + timestamp + Constants.DELIMITER + transactionId);
+    history.setEntity(Constants.HISTORY_ENTITY);
+    history.setStatus(NotificationStatus.FAIL.getValue());
+    history.setNotificationType("sendPushNotification");
+
+    boolean validUserId = userId != null && !userId.isBlank();
+    if (validUserId) {
+      Set<String> userIds = new HashSet<>();
+      userIds.add(userId);
+      history.setUserIds(userIds);
+    }
+
+    boolean validMessageId = messageId != null && !messageId.isBlank();
+    if (validMessageId) {
+      Set<String> messageIds = new HashSet<>();
+      messageIds.add(messageId);
+      history.setMessageIds(messageIds);
+    }
+    historyRepository.save(history);
+  }
 }

--- a/src/main/java/com/sopt/push/lambda/SnsHandler.java
+++ b/src/main/java/com/sopt/push/lambda/SnsHandler.java
@@ -22,7 +22,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 
@@ -54,7 +53,8 @@ public class SnsHandler implements RequestHandler<SNSEvent, Void> {
 
   @Override
   public Void handleRequest(SNSEvent event, Context context) {
-    boolean invalidEvent = event == null || event.getRecords() == null || event.getRecords().isEmpty();
+    boolean invalidEvent =
+        event == null || event.getRecords() == null || event.getRecords().isEmpty();
     if (invalidEvent) {
       log.warn("SNS event is null or has no records");
       return null;
@@ -84,7 +84,7 @@ public class SnsHandler implements RequestHandler<SNSEvent, Void> {
   }
 
   private void processFailureRecords(
-          List<SNSEvent.SNSRecord> records, Map<String, DeviceTokenEntity> tokenToEntity) {
+      List<SNSEvent.SNSRecord> records, Map<String, DeviceTokenEntity> tokenToEntity) {
     for (SNSEvent.SNSRecord record : records) {
       String token = extractTokenFromRecord(record);
       boolean invalidToken = token == null || token.isBlank();
@@ -150,7 +150,8 @@ public class SnsHandler implements RequestHandler<SNSEvent, Void> {
 
   private void createFailureHistory(String userId, String messageId) {
     ZonedDateTime now = ZonedDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
-    String yearMonth = String.format(Constants.YEAR_MONTH_FORMAT, now.getYear(), now.getMonthValue());
+    String yearMonth =
+        String.format(Constants.YEAR_MONTH_FORMAT, now.getYear(), now.getMonthValue());
     String timestamp = DateTimeFormatter.ISO_INSTANT.format(now.toInstant());
     String transactionId = UUID.randomUUID().toString();
     HistoryEntity history = new HistoryEntity();

--- a/src/main/java/com/sopt/push/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/sopt/push/repository/DeviceTokenRepository.java
@@ -30,9 +30,10 @@ public class DeviceTokenRepository {
   }
 
   public Optional<DeviceTokenEntity> findByPk(String pk) {
-    var queryResult = deviceTokenTable.query(
-        software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo(
-            Key.builder().partitionValue(pk).build()));
+    var queryResult =
+        deviceTokenTable.query(
+            software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo(
+                Key.builder().partitionValue(pk).build()));
     return queryResult.items().stream().findFirst();
   }
 }

--- a/src/main/java/com/sopt/push/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/sopt/push/repository/DeviceTokenRepository.java
@@ -28,4 +28,11 @@ public class DeviceTokenRepository {
     Key key = Key.builder().partitionValue(pk).sortValue(sk).build();
     return Optional.ofNullable(deviceTokenTable.getItem(key));
   }
+
+  public Optional<DeviceTokenEntity> findByPk(String pk) {
+    var queryResult = deviceTokenTable.query(
+        software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo(
+            Key.builder().partitionValue(pk).build()));
+    return queryResult.items().stream().findFirst();
+  }
 }

--- a/src/main/java/com/sopt/push/service/NotificationService.java
+++ b/src/main/java/com/sopt/push/service/NotificationService.java
@@ -1,5 +1,92 @@
 package com.sopt.push.service;
 
+import com.sopt.push.common.BusinessException;
+import com.sopt.push.common.ErrorMessage;
+import com.sopt.push.config.EnvConfig;
+import com.sopt.push.dto.MessageFactoryDto;
+import com.sopt.push.dto.PushMessagePayloadDto;
+import com.sopt.push.dto.ResponsePushNotificationDto;
+import com.sopt.push.enums.Platform;
+import com.sopt.push.enums.PushTopic;
+import com.sopt.push.message.MessageCreator;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class NotificationService {
-  // TODO: Implement notification service
+
+  private final SnsService snsService;
+  private final EnvConfig envConfig;
+
+  public Optional<ResponsePushNotificationDto> sendPlatformPushMessage(
+      PushMessagePayloadDto messagePayload, String endpointArn, Platform platform) {
+
+    validatePayload(messagePayload);
+
+    boolean invalidEndpointArn = endpointArn == null || endpointArn.isBlank();
+
+    if (invalidEndpointArn) {
+      throw new BusinessException(ErrorMessage.INVALID_REQUEST, "endpointArn is null or blank");
+    }
+
+    MessageFactoryDto dto =
+        new MessageFactoryDto(
+            platform.getTopic(),
+            messagePayload.id(),
+            messagePayload.title(),
+            messagePayload.content(),
+            messagePayload.category(),
+            messagePayload.deepLink(),
+            messagePayload.webLink());
+
+    String messageJson = MessageCreator.create(dto);
+    return sendPushMessage(endpointArn, messageJson, false);
+  }
+
+  public Optional<ResponsePushNotificationDto> sendAllTopicPushMessage(
+      PushMessagePayloadDto messagePayload) {
+
+    validatePayload(messagePayload);
+
+    MessageFactoryDto dto =
+        new MessageFactoryDto(
+            PushTopic.ALL,
+            messagePayload.id(),
+            messagePayload.title(),
+            messagePayload.content(),
+            messagePayload.category(),
+            messagePayload.deepLink(),
+            messagePayload.webLink());
+
+    String messageJson = MessageCreator.create(dto);
+    String topicArn = envConfig.getAllTopicArn();
+    return sendPushMessage(topicArn, messageJson, true);
+  }
+
+  private void validatePayload(PushMessagePayloadDto messagePayload) {
+    boolean invalidId = messagePayload.id() == null || messagePayload.id().isBlank();
+    boolean invalidTitle = messagePayload.title() == null || messagePayload.title().isBlank();
+    boolean invalidContent = messagePayload.content() == null || messagePayload.content().isBlank();
+    boolean invalidCategory = messagePayload.category() == null;
+
+    if (invalidId || invalidTitle || invalidContent || invalidCategory) {
+      throw new BusinessException(ErrorMessage.INVALID_REQUEST, "Invalid push message payload");
+    }
+  }
+
+  private Optional<ResponsePushNotificationDto> sendPushMessage(
+      String arn, String messageJson, boolean sendAll) {
+    var publishResponse =
+        sendAll
+            ? snsService.publishToTopicArn(arn, messageJson)
+            : snsService.publishToEndpoint(arn, messageJson);
+    String messageId = publishResponse.messageId();
+    boolean invalidMessageId = messageId == null || messageId.isBlank();
+
+    if (invalidMessageId) {
+      return Optional.empty();
+    }
+
+    return Optional.of(new ResponsePushNotificationDto(messageId));
+  }
 }

--- a/src/main/java/com/sopt/push/service/SnsService.java
+++ b/src/main/java/com/sopt/push/service/SnsService.java
@@ -1,0 +1,164 @@
+package com.sopt.push.service;
+
+import com.sopt.push.client.SnsClientProvider;
+import com.sopt.push.common.ExternalException;
+import com.sopt.push.config.EnvConfig;
+import com.sopt.push.enums.Platform;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.CreatePlatformEndpointRequest;
+import software.amazon.awssdk.services.sns.model.CreatePlatformEndpointResponse;
+import software.amazon.awssdk.services.sns.model.DeleteEndpointRequest;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+import software.amazon.awssdk.services.sns.model.SubscribeRequest;
+import software.amazon.awssdk.services.sns.model.SubscribeResponse;
+import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SnsService {
+
+  private static final String MESSAGE_STRUCTURE_JSON = "json";
+  private static final String APPLICATION_PROTOCOL = "application";
+
+  private final EnvConfig envConfig;
+  private final SnsClient snsClient = SnsClientProvider.getClient();
+
+  public SubscribeResponse subscribe(String endpointArn) {
+    SubscribeRequest request =
+        SubscribeRequest.builder()
+            .topicArn(envConfig.getAllTopicArn())
+            .protocol(APPLICATION_PROTOCOL)
+            .endpoint(endpointArn)
+            .build();
+    SubscribeResponse response = snsClient.subscribe(request);
+    boolean hasError =
+        response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
+
+    if (hasError) {
+      log.error("SNS subscribe error: {}", response);
+      throw new ExternalException("SNS subscribe failed");
+    }
+    return response;
+  }
+
+  public void unsubscribe(String subscriptionArn) {
+    UnsubscribeRequest request =
+        UnsubscribeRequest.builder().subscriptionArn(subscriptionArn).build();
+    var response = snsClient.unsubscribe(request);
+    boolean hasError =
+        response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
+
+    if (hasError) {
+      log.error("SNS unsubscribe error: {}", response);
+      throw new ExternalException("SNS unsubscribe failed");
+    }
+  }
+
+  public CreatePlatformEndpointResponse registerEndpoint(
+      String deviceToken, Platform platform, String userId) {
+    String platformApplicationArn =
+        switch (platform) {
+          case IOS -> envConfig.getPlatformApplicationIosArn();
+          case ANDROID -> envConfig.getPlatformApplicationAndroidArn();
+        };
+    CreatePlatformEndpointRequest.Builder builder =
+        CreatePlatformEndpointRequest.builder()
+            .platformApplicationArn(platformApplicationArn)
+            .token(deviceToken);
+
+    if (userId != null && !userId.isBlank()) {
+      builder.customUserData(userId);
+    }
+
+    CreatePlatformEndpointResponse response = snsClient.createPlatformEndpoint(builder.build());
+    boolean hasError =
+        response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
+
+    if (hasError) {
+      log.error("SNS register endpoint error: {}", response);
+      throw new ExternalException("SNS register endpoint failed");
+    }
+    return response;
+  }
+
+  public void cancelEndpoint(String endpointArn) {
+    DeleteEndpointRequest request =
+        DeleteEndpointRequest.builder().endpointArn(endpointArn).build();
+    var response = snsClient.deleteEndpoint(request);
+    boolean hasError =
+        response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
+
+    if (hasError) {
+      log.error("SNS delete endpoint error: {}", response);
+      throw new ExternalException("SNS delete endpoint failed");
+    }
+  }
+
+  public PublishResponse publishToTopicArn(String topicArn, String messageJson) {
+    try {
+      PublishRequest request =
+          PublishRequest.builder()
+              .topicArn(topicArn)
+              .message(messageJson)
+              .messageStructure(MESSAGE_STRUCTURE_JSON)
+              .build();
+      PublishResponse response = snsClient.publish(request);
+      boolean hasError =
+          response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
+
+      if (hasError) {
+        log.error("SNS publish TopicArn error: {}", response);
+        throw new ExternalException("SNS publish to topic failed");
+      }
+      return response;
+    } catch (AwsServiceException e) {
+      log.error("SNS publish TopicArn AWS service error", e);
+      throw new ExternalException(
+          "AWS service error during publish to topic: " + e.awsErrorDetails(), e);
+    } catch (SdkClientException e) {
+      log.error("SNS publish TopicArn SDK client error", e);
+      throw new ExternalException("SDK client error during publish to topic: " + e.getMessage(), e);
+    } catch (RuntimeException e) {
+      log.error("SNS publish TopicArn unexpected error", e);
+      throw new ExternalException(
+          "Unexpected error during publish to topic: " + e.getMessage(), e);
+    }
+  }
+
+  public PublishResponse publishToEndpoint(String endpointArn, String messageJson) {
+    try {
+      PublishRequest request =
+          PublishRequest.builder()
+              .targetArn(endpointArn)
+              .message(messageJson)
+              .messageStructure(MESSAGE_STRUCTURE_JSON)
+              .build();
+      PublishResponse response = snsClient.publish(request);
+      boolean hasError =
+          response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
+
+      if (hasError) {
+        log.error("SNS endpoint publish error: {}", response);
+        throw new ExternalException("SNS publish to endpoint failed");
+      }
+      return response;
+    } catch (AwsServiceException e) {
+      log.error("SNS endpoint publish AWS service error", e);
+      throw new ExternalException(
+          "AWS service error during publish to endpoint: " + e.awsErrorDetails(), e);
+    } catch (SdkClientException e) {
+      log.error("SNS endpoint publish SDK client error", e);
+      throw new ExternalException(
+          "SDK client error during publish to endpoint: " + e.getMessage(), e);
+    } catch (RuntimeException e) {
+      log.error("SNS endpoint publish unexpected error", e);
+      throw new ExternalException(
+          "Unexpected error during publish to endpoint: " + e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/java/com/sopt/push/service/SnsService.java
+++ b/src/main/java/com/sopt/push/service/SnsService.java
@@ -1,5 +1,8 @@
 package com.sopt.push.service;
 
+import static com.sopt.push.common.Constants.APPLICATION_PROTOCOL;
+import static com.sopt.push.common.Constants.JSON;
+
 import com.sopt.push.client.SnsClientProvider;
 import com.sopt.push.common.ExternalException;
 import com.sopt.push.config.EnvConfig;
@@ -17,9 +20,6 @@ import software.amazon.awssdk.services.sns.model.PublishResponse;
 import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sns.model.SubscribeResponse;
 import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
-
-import static com.sopt.push.common.Constants.APPLICATION_PROTOCOL;
-import static com.sopt.push.common.Constants.JSON;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -76,8 +76,7 @@ public class SnsService {
       builder.customUserData(userId);
     }
 
-    CreatePlatformEndpointResponse response =
-        snsClient.createPlatformEndpoint(builder.build());
+    CreatePlatformEndpointResponse response = snsClient.createPlatformEndpoint(builder.build());
     boolean hasError =
         response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
 

--- a/src/main/java/com/sopt/push/service/SnsService.java
+++ b/src/main/java/com/sopt/push/service/SnsService.java
@@ -71,11 +71,13 @@ public class SnsService {
             .platformApplicationArn(platformApplicationArn)
             .token(deviceToken);
 
-    if (userId != null && !userId.isBlank()) {
+    boolean hasUserId = userId != null && !userId.isBlank();
+    if (hasUserId) {
       builder.customUserData(userId);
     }
 
-    CreatePlatformEndpointResponse response = snsClient.createPlatformEndpoint(builder.build());
+    CreatePlatformEndpointResponse response =
+        snsClient.createPlatformEndpoint(builder.build());
     boolean hasError =
         response.sdkHttpResponse() == null || !response.sdkHttpResponse().isSuccessful();
 

--- a/src/main/java/com/sopt/push/service/SnsService.java
+++ b/src/main/java/com/sopt/push/service/SnsService.java
@@ -18,11 +18,12 @@ import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sns.model.SubscribeResponse;
 import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
 
+import static com.sopt.push.common.Constants.JSON;
+
 @Slf4j
 @RequiredArgsConstructor
 public class SnsService {
 
-  private static final String MESSAGE_STRUCTURE_JSON = "json";
   private static final String APPLICATION_PROTOCOL = "application";
 
   private final EnvConfig envConfig;
@@ -107,7 +108,7 @@ public class SnsService {
           PublishRequest.builder()
               .topicArn(topicArn)
               .message(messageJson)
-              .messageStructure(MESSAGE_STRUCTURE_JSON)
+              .messageStructure(JSON)
               .build();
       PublishResponse response = snsClient.publish(request);
       boolean hasError =
@@ -137,7 +138,7 @@ public class SnsService {
           PublishRequest.builder()
               .targetArn(endpointArn)
               .message(messageJson)
-              .messageStructure(MESSAGE_STRUCTURE_JSON)
+              .messageStructure(JSON)
               .build();
       PublishResponse response = snsClient.publish(request);
       boolean hasError =

--- a/src/main/java/com/sopt/push/service/SnsService.java
+++ b/src/main/java/com/sopt/push/service/SnsService.java
@@ -18,13 +18,12 @@ import software.amazon.awssdk.services.sns.model.SubscribeRequest;
 import software.amazon.awssdk.services.sns.model.SubscribeResponse;
 import software.amazon.awssdk.services.sns.model.UnsubscribeRequest;
 
+import static com.sopt.push.common.Constants.APPLICATION_PROTOCOL;
 import static com.sopt.push.common.Constants.JSON;
 
 @Slf4j
 @RequiredArgsConstructor
 public class SnsService {
-
-  private static final String APPLICATION_PROTOCOL = "application";
 
   private final EnvConfig envConfig;
   private final SnsClient snsClient = SnsClientProvider.getClient();

--- a/src/main/java/com/sopt/push/service/SnsService.java
+++ b/src/main/java/com/sopt/push/service/SnsService.java
@@ -125,8 +125,7 @@ public class SnsService {
       throw new ExternalException("SDK client error during publish to topic: " + e.getMessage(), e);
     } catch (RuntimeException e) {
       log.error("SNS publish TopicArn unexpected error", e);
-      throw new ExternalException(
-          "Unexpected error during publish to topic: " + e.getMessage(), e);
+      throw new ExternalException("Unexpected error during publish to topic: " + e.getMessage(), e);
     }
   }
 

--- a/src/main/java/com/sopt/push/service/UserService.java
+++ b/src/main/java/com/sopt/push/service/UserService.java
@@ -1,5 +1,23 @@
 package com.sopt.push.service;
 
+import com.sopt.push.domain.DeviceTokenEntity;
+import com.sopt.push.repository.DeviceTokenRepository;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class UserService {
-  // TODO: Implement user service
+
+  private final DeviceTokenRepository deviceTokenRepository;
+  private final SnsService snsService;
+
+  public void unregisterToken(DeviceTokenEntity deviceTokenEntity) {
+    String subscriptionArn = deviceTokenEntity.getSubscriptionArn();
+    String endpointArn = deviceTokenEntity.getEndpointArn();
+    String pk = deviceTokenEntity.getPk();
+    String sk = deviceTokenEntity.getSk();
+
+    snsService.unsubscribe(subscriptionArn);
+    snsService.cancelEndpoint(endpointArn);
+    deviceTokenRepository.delete(pk, sk);
+  }
 }

--- a/src/main/java/com/sopt/push/service/UserService.java
+++ b/src/main/java/com/sopt/push/service/UserService.java
@@ -1,14 +1,61 @@
 package com.sopt.push.service;
 
+import com.sopt.push.common.Constants;
+import com.sopt.push.common.ExternalException;
 import com.sopt.push.domain.DeviceTokenEntity;
+import com.sopt.push.domain.UserEntity;
+import com.sopt.push.enums.Platform;
 import com.sopt.push.repository.DeviceTokenRepository;
+import com.sopt.push.repository.UserRepository;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 public class UserService {
 
   private final DeviceTokenRepository deviceTokenRepository;
+  private final UserRepository userRepository;
   private final SnsService snsService;
+
+  public void registerToken(String deviceToken, Platform platform, String userId) {
+    Optional<DeviceTokenEntity> existingTokenOptional = findDeviceTokenByToken(deviceToken);
+
+    if (existingTokenOptional.isPresent()) {
+      DeviceTokenEntity existingToken = existingTokenOptional.get();
+      String existingUserId = extractUserIdFromSk(existingToken.getSk());
+      boolean userChanged = hasUserChanged(existingUserId, userId);
+
+      if (!userChanged) {
+        return;
+      }
+      unregisterToken(existingToken);
+    }
+
+    var endpointResponse = snsService.registerEndpoint(deviceToken, platform, userId);
+    String endpointArn = endpointResponse.endpointArn();
+    boolean invalidEndpointArn = endpointArn == null || endpointArn.isBlank();
+    if (invalidEndpointArn) {
+      log.error("endpointArn is undefined");
+      throw new ExternalException("endpointArn is undefined");
+    }
+
+    var subscribeResponse = snsService.subscribe(endpointArn);
+    String subscriptionArn = subscribeResponse.subscriptionArn();
+    boolean invalidSubscriptionArn = subscriptionArn == null || subscriptionArn.isBlank();
+    if (invalidSubscriptionArn) {
+      log.error("subscriptionArn is undefined");
+      throw new ExternalException("subscriptionArn is undefined");
+    }
+
+    String actualUserId = userId != null && !userId.isBlank() ? userId : Constants.UNKNOWN_USER;
+    String createdAt = DateTimeFormatter.ISO_INSTANT.format(Instant.now());
+
+    saveTokenEntities(deviceToken, platform, endpointArn, subscriptionArn, actualUserId, createdAt);
+  }
 
   public void unregisterToken(DeviceTokenEntity deviceTokenEntity) {
     String subscriptionArn = deviceTokenEntity.getSubscriptionArn();
@@ -19,5 +66,80 @@ public class UserService {
     snsService.unsubscribe(subscriptionArn);
     snsService.cancelEndpoint(endpointArn);
     deviceTokenRepository.delete(pk, sk);
+
+    String userId = extractUserIdFromSk(sk);
+    String userPk = Constants.USER_PREFIX + userId;
+    String userSk = Constants.TOKEN_PREFIX + extractTokenFromPk(pk);
+    userRepository.delete(userPk, userSk);
+  }
+
+  private Optional<DeviceTokenEntity> findDeviceTokenByToken(String deviceToken) {
+    String pk = Constants.TOKEN_PREFIX + deviceToken;
+    return deviceTokenRepository.findByPk(pk);
+  }
+
+  private boolean hasUserChanged(String existingUserId, String newUserId) {
+    boolean sameUserId = existingUserId != null && existingUserId.equals(newUserId);
+    if (sameUserId) {
+      return false;
+    }
+
+    boolean newUserIdIsUnknown = newUserId == null || newUserId.isBlank();
+    boolean existingUserIdIsUnknown = Constants.UNKNOWN_USER.equals(existingUserId);
+    boolean bothUnknown = newUserIdIsUnknown && existingUserIdIsUnknown;
+    return !bothUnknown;
+  }
+
+  private String extractUserIdFromSk(String sk) {
+    boolean invalidSk = sk == null || !sk.contains(Constants.DELIMITER);
+    if (invalidSk) {
+      return null;
+    }
+    String[] parts = sk.split(Constants.DELIMITER, 2);
+    boolean validParts = parts.length == 2;
+    return validParts ? parts[1] : null;
+  }
+
+  private String extractTokenFromPk(String pk) {
+    boolean invalidPk = pk == null || !pk.startsWith(Constants.TOKEN_PREFIX);
+    if (invalidPk) {
+      return null;
+    }
+    return pk.substring(Constants.TOKEN_PREFIX.length());
+  }
+
+  private void saveTokenEntities(
+      String deviceToken,
+      Platform platform,
+      String endpointArn,
+      String subscriptionArn,
+      String userId,
+      String createdAt) {
+
+    String userPk = Constants.USER_PREFIX + userId;
+    String userSk = Constants.TOKEN_PREFIX + deviceToken;
+    String tokenPk = Constants.TOKEN_PREFIX + deviceToken;
+    String tokenSk = Constants.USER_PREFIX + userId;
+
+    UserEntity userEntity = new UserEntity();
+    userEntity.setPk(userPk);
+    userEntity.setSk(userSk);
+    userEntity.setEntity(Constants.USER_ENTITY);
+    userEntity.setPlatform(platform.getValue());
+    userEntity.setEndpointArn(endpointArn);
+    userEntity.setSubscriptionArn(subscriptionArn);
+    userEntity.setCreatedAt(createdAt);
+
+    DeviceTokenEntity deviceTokenEntity = new DeviceTokenEntity();
+    deviceTokenEntity.setPk(tokenPk);
+    deviceTokenEntity.setSk(tokenSk);
+    deviceTokenEntity.setEntity(Constants.DEVICE_TOKEN_ENTITY);
+    deviceTokenEntity.setPlatform(platform.getValue());
+    deviceTokenEntity.setEndpointArn(endpointArn);
+    deviceTokenEntity.setSubscriptionArn(subscriptionArn);
+    deviceTokenEntity.setCreatedAt(createdAt);
+
+    userRepository.save(userEntity);
+    deviceTokenRepository.save(deviceTokenEntity);
   }
 }


### PR DESCRIPTION
<!--
name: Makers Push Notification Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #13 

## Work Description ✏️
1. SNS 실패 콜백 핸들러 (SnsHandler)
- SNSEvent 수신 및 처리
- 이벤트 유효성 검사
2. 토큰 추출 및 조회
- SNS 메시지에서 Token 추출 (extractTokenFromRecord)
- 토큰으로 DeviceTokenEntity 조회 (collectTokenEntities)
- DeviceTokenRepository.findByPk 구현
3. 실패 로그 기록
- createFailureHistory 메서드 구현
- HistoryEntity에 실패 상태, userId, messageId 저장
- DynamoDB에 저장 (HistoryRepository.save)
4. 토큰 무효화
- UserService.unregisterToken 구현
- SNS 구독 해제 (snsService.unsubscribe)
- SNS 엔드포인트 삭제 (snsService.cancelEndpoint)
- DynamoDB에서 UserEntity와 DeviceTokenEntity 삭제

## PR Point 📸
<!-- 피드백을 받고 싶은 부분을 적어주세요. -->
