### PR TITLE
[Feat/#29] SQS, DLQ를 통한 실패 추적 파이프라인 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+This is a Java 21 AWS Lambda push notification service built with Gradle and SAM. Code lives under `src/main/java/com/sopt/push`:
+
+- `lambda/`: handlers for API Gateway, EventBridge, and SNS.
+- `service/`, `repository/`, `client/`: business logic, DynamoDB access, and AWS SDK providers.
+- `dto/`, `domain/`, `enums/`, `common/`, `util/`, `config/`: request models, persistence models, shared constants, utilities, and wiring.
+- `src/main/resources/logback.xml`: logging configuration.
+- `events/`: SAM payloads for API Gateway, SNS, and EventBridge.
+- `template.yaml`: SAM infrastructure.
+- `config/checkstyle/checkstyle.xml`: style rules.
+
+Add tests under `src/test/java` using the production package layout.
+
+## Build, Test, and Development Commands
+
+- `./gradlew build`: compiles, checks, tests, and builds the Lambda fat jar.
+- `./gradlew shadowJar`: creates `build/libs/app.jar`.
+- `./gradlew test`: runs JUnit 5 tests.
+- `./gradlew check`: runs tests, Checkstyle, and Spotless format checks.
+- `./gradlew format`: applies Spotless formatting with Google Java Format.
+- `sam build`: builds the SAM application after `build/libs/app.jar` exists.
+- `sam local invoke SnsHandlerFunction --event events/sns-event-single.json --env-vars params-dev.json`: invokes SNS locally.
+- `./test-sns-handler.sh`: SNS handler local testing helper.
+
+## Coding Style & Naming Conventions
+
+Use Java 21 features conservatively and follow the existing package structure. Spotless applies Google Java Format, removes unused imports, trims whitespace, and requires a final newline. Checkstyle enforces naming, braces, import hygiene, 150-line methods, and 7-parameter methods.
+
+Name DTOs with the existing `*Dto` suffix, domain entities with `*Entity`, Lambda handlers with `*Handler`, services with `*Service` or `*Facade`, and AWS clients with `*ClientProvider`.
+
+## Testing Guidelines
+
+Use JUnit Jupiter and Mockito. Name test classes after the class under test, for example `ApiGatewayHandlerTest`. Prefer focused unit tests for services and utilities, and use `events/*.json` plus SAM for handler-level checks. Run `./gradlew test` before opening a PR; run `./gradlew check` when style may be affected.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use uppercase bracketed types, sometimes with an issue number, such as `[FIX] ...`, `[DOCS] ...`, and `[CHORE/#26] ...`. Keep messages concise and action-oriented.
+
+Pull requests should include a problem summary, approach, test evidence, and any deployment or environment changes. For Lambda behavior changes, mention affected handlers and the sample events or SAM commands used.
+
+## Security & Configuration Tips
+
+Do not commit AWS credentials, real device tokens, production ARNs, or local `params-dev.json` files containing secrets. Keep environment-specific values in AWS/SAM parameters or local ignored files, and use example values in `events/` unless a test explicitly requires real data.

--- a/events/sqs-push-failure.json
+++ b/events/sqs-push-failure.json
@@ -1,0 +1,20 @@
+{
+  "Records": [
+    {
+      "messageId": "11111111-2222-3333-4444-555555555555",
+      "receiptHandle": "example-receipt-handle",
+      "body": "{\"Type\":\"Notification\",\"MessageId\":\"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"TopicArn\":\"arn:aws:sns:ap-northeast-2:123456789012:push-failures\",\"Message\":\"{\\\"Token\\\":\\\"actual-device-token\\\",\\\"EndpointArn\\\":\\\"arn:aws:sns:ap-northeast-2:123456789012:endpoint/APNS/test-app/test-endpoint\\\",\\\"MessageId\\\":\\\"알림 서버 실패 추적 개발 테스트용 알림입니다 ㅎ ㅎ\\\"}\",\"Timestamp\":\"2026-08-10T00:00:00.000Z\"}",
+      "attributes": {
+        "ApproximateReceiveCount": "1",
+        "SentTimestamp": "1786320000000",
+        "SenderId": "AIDAEXAMPLE",
+        "ApproximateFirstReceiveTimestamp": "1786320000001"
+      },
+      "messageAttributes": {},
+      "md5OfBody": "example-md5",
+      "eventSource": "aws:sqs",
+      "eventSourceARN": "arn:aws:sqs:ap-northeast-2:123456789012:sopt-push-failure-queue-dev",
+      "awsRegion": "ap-northeast-2"
+    }
+  ]
+}

--- a/src/main/java/com/sopt/push/config/AppFactory.java
+++ b/src/main/java/com/sopt/push/config/AppFactory.java
@@ -10,6 +10,7 @@ import com.sopt.push.service.EndpointFacade;
 import com.sopt.push.service.HistoryService;
 import com.sopt.push.service.NotificationService;
 import com.sopt.push.service.SendPushFacade;
+import com.sopt.push.service.SlackAlertService;
 import com.sopt.push.service.UserService;
 import com.sopt.push.service.WebHookService;
 import java.net.http.HttpClient;
@@ -28,6 +29,7 @@ public class AppFactory {
   private final HistoryService historyService;
   private final DeviceTokenService deviceTokenService;
   private final NotificationService notificationService;
+  private final SlackAlertService slackAlertService;
 
   private AppFactory() {
 
@@ -50,6 +52,7 @@ public class AppFactory {
     this.historyService = new HistoryService(historyRepository);
     this.deviceTokenService = new DeviceTokenService(tokenRepository);
     this.notificationService = new NotificationService(snsClient, envConfig);
+    this.slackAlertService = new SlackAlertService(httpClient, envConfig);
     this.endpointFacade =
         new EndpointFacade(this.deviceTokenService, this.userService, this.notificationService);
 
@@ -90,5 +93,9 @@ public class AppFactory {
 
   public EndpointFacade endpointFacade() {
     return endpointFacade;
+  }
+
+  public SlackAlertService slackAlertService() {
+    return slackAlertService;
   }
 }

--- a/src/main/java/com/sopt/push/config/EnvConfig.java
+++ b/src/main/java/com/sopt/push/config/EnvConfig.java
@@ -11,6 +11,7 @@ public final class EnvConfig {
   private static final String MAKERS_OPERATION_SERVER_URL = "MAKERS_OPERATION_SERVER_URL";
   private static final String PLATFORM_APPLICATION_IOS_ENV = "PLATFORM_APPLICATION_iOS";
   private static final String PLATFORM_APPLICATION_ANDROID_ENV = "PLATFORM_APPLICATION_ANDROID";
+  private static final String SLACK_FAILURE_WEBHOOK_URL_ENV = "SLACK_FAILURE_WEBHOOK_URL";
 
   private final String dynamoDbTableName;
   private final String allTopicArn;
@@ -18,6 +19,7 @@ public final class EnvConfig {
   private final String makersOperationServerUrl;
   private final String platformApplicationIosArn;
   private final String platformApplicationAndroidArn;
+  private final String slackFailureWebhookUrl;
 
   public EnvConfig() {
     this.dynamoDbTableName = getRequiredEnv(DYNAMODB_TABLE_ENV_VAR);
@@ -26,6 +28,7 @@ public final class EnvConfig {
     this.makersOperationServerUrl = getRequiredEnv(MAKERS_OPERATION_SERVER_URL);
     this.platformApplicationIosArn = getRequiredEnv(PLATFORM_APPLICATION_IOS_ENV);
     this.platformApplicationAndroidArn = getRequiredEnv(PLATFORM_APPLICATION_ANDROID_ENV);
+    this.slackFailureWebhookUrl = getOptionalEnv(SLACK_FAILURE_WEBHOOK_URL_ENV);
   }
 
   private static String getRequiredEnv(String key) {
@@ -34,5 +37,10 @@ public final class EnvConfig {
       throw new IllegalStateException("Required environment variable '" + key + "' is not set.");
     }
     return value;
+  }
+
+  private static String getOptionalEnv(String key) {
+    String value = System.getenv(key);
+    return value == null || value.isBlank() ? null : value;
   }
 }

--- a/src/main/java/com/sopt/push/lambda/SqsHandler.java
+++ b/src/main/java/com/sopt/push/lambda/SqsHandler.java
@@ -146,7 +146,22 @@ public class SqsHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
     return node == null || node.isMissingNode() || node.asText().isBlank() ? null : node.asText();
   }
 
-  private record FailureMessage(String token, String messageId) {
+  private static final class FailureMessage {
 
+    private final String token;
+    private final String messageId;
+
+    private FailureMessage(String token, String messageId) {
+      this.token = token;
+      this.messageId = messageId;
+    }
+
+    private String token() {
+      return token;
+    }
+
+    private String messageId() {
+      return messageId;
+    }
   }
 }

--- a/src/main/java/com/sopt/push/lambda/SqsHandler.java
+++ b/src/main/java/com/sopt/push/lambda/SqsHandler.java
@@ -1,0 +1,152 @@
+package com.sopt.push.lambda;
+
+import static com.sopt.push.common.Constants.TOKEN;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.push.config.AppFactory;
+import com.sopt.push.config.ObjectMapperConfig;
+import com.sopt.push.domain.DeviceTokenEntity;
+import com.sopt.push.dto.CreateHistoryDto;
+import com.sopt.push.dto.UserTokenInfoDto;
+import com.sopt.push.enums.NotificationStatus;
+import com.sopt.push.enums.NotificationType;
+import com.sopt.push.service.DeviceTokenService;
+import com.sopt.push.service.EndpointFacade;
+import com.sopt.push.service.HistoryService;
+import com.sopt.push.service.SlackAlertService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SqsHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
+
+  private static final String MESSAGE = "Message";
+  private static final String MESSAGE_ID = "MessageId";
+
+  private final DeviceTokenService deviceTokenService;
+  private final HistoryService historyService;
+  private final EndpointFacade endpointFacade;
+  private final SlackAlertService slackAlertService;
+  private final ObjectMapper objectMapper;
+
+  public SqsHandler() {
+    AppFactory factory = AppFactory.getInstance();
+    this.deviceTokenService = factory.deviceTokenService();
+    this.historyService = factory.historyService();
+    this.endpointFacade = factory.endpointFacade();
+    this.slackAlertService = factory.slackAlertService();
+    this.objectMapper = ObjectMapperConfig.getObjectMapper();
+  }
+
+  @Override
+  public SQSBatchResponse handleRequest(SQSEvent event, Context context) {
+    List<SQSBatchResponse.BatchItemFailure> failures = new ArrayList<>();
+
+    if (event == null || event.getRecords() == null || event.getRecords().isEmpty()) {
+      log.warn("SQS event is null or has no records");
+      return new SQSBatchResponse(failures);
+    }
+
+    log.info("Received SQS records count={}", event.getRecords().size());
+
+    for (SQSEvent.SQSMessage record : event.getRecords()) {
+      try {
+        processRecord(record);
+      } catch (Exception ex) {
+        log.error("Failed to process SQS record. messageId={}", record.getMessageId(), ex);
+        slackAlertService.notifyProcessingFailure(record.getMessageId(), ex.getMessage());
+        failures.add(new SQSBatchResponse.BatchItemFailure(record.getMessageId()));
+      }
+    }
+
+    return new SQSBatchResponse(failures);
+  }
+
+  private void processRecord(SQSEvent.SQSMessage record) throws Exception {
+    FailureMessage failureMessage = extractFailureMessage(record);
+    String token = failureMessage.token();
+
+    if (token == null || token.isBlank()) {
+      slackAlertService.notifyProcessingFailure(record.getMessageId(), "Missing device token");
+      log.warn("Push failure message has no token. sqsMessageId={}", record.getMessageId());
+      return;
+    }
+
+    DeviceTokenEntity tokenEntity = deviceTokenService.findByDeviceToken(token).orElse(null);
+    if (tokenEntity == null) {
+      log.info("No token entity found for failed token. sqsMessageId={}", record.getMessageId());
+      slackAlertService.notifyPushFailure(null, token, failureMessage.messageId());
+      return;
+    }
+
+    UserTokenInfoDto userTokenInfoDto =
+        deviceTokenService.mapDeviceTokenEntityToInfoDto(tokenEntity);
+    log.info(
+        "Processing invalid push endpoint for userId={}, messageId={}",
+        userTokenInfoDto.userId(),
+        failureMessage.messageId());
+
+    createFailLog(userTokenInfoDto.userId(), failureMessage.messageId());
+    endpointFacade.clean(userTokenInfoDto);
+    slackAlertService.notifyPushFailure(
+        userTokenInfoDto.userId(), userTokenInfoDto.deviceToken(), failureMessage.messageId());
+  }
+
+  private FailureMessage extractFailureMessage(SQSEvent.SQSMessage record) throws Exception {
+    JsonNode body = objectMapper.readTree(record.getBody());
+    String messageId = textOrNull(body.path(MESSAGE_ID));
+    JsonNode payload = body;
+
+    if (body.hasNonNull(MESSAGE)) {
+      payload = objectMapper.readTree(body.path(MESSAGE).asText());
+    }
+
+    String token = textOrNull(payload.path(TOKEN));
+    String payloadMessageId = textOrNull(payload.path(MESSAGE_ID));
+    String fallbackMessageId = messageId != null ? messageId : record.getMessageId();
+    return new FailureMessage(
+        token, payloadMessageId != null ? payloadMessageId : fallbackMessageId);
+  }
+
+  private void createFailLog(String userId, String messageId) {
+    Set<String> userIds = userId != null && !userId.isBlank() ? Set.of(userId) : null;
+    Set<String> messageIds = messageId != null && !messageId.isBlank() ? Set.of(messageId) : null;
+
+    CreateHistoryDto createHistoryDto =
+        new CreateHistoryDto(
+            UUID.randomUUID().toString(),
+            null,
+            null,
+            null,
+            null,
+            NotificationType.PUSH.getValue(),
+            null,
+            NotificationStatus.FAIL.getValue(),
+            null,
+            null,
+            null,
+            null,
+            userIds,
+            null,
+            messageIds,
+            null,
+            null);
+    historyService.createLog(createHistoryDto);
+  }
+
+  private String textOrNull(JsonNode node) {
+    return node == null || node.isMissingNode() || node.asText().isBlank() ? null : node.asText();
+  }
+
+  private record FailureMessage(String token, String messageId) {
+
+  }
+}

--- a/src/main/java/com/sopt/push/lambda/SqsHandler.java
+++ b/src/main/java/com/sopt/push/lambda/SqsHandler.java
@@ -19,6 +19,8 @@ import com.sopt.push.service.DeviceTokenService;
 import com.sopt.push.service.EndpointFacade;
 import com.sopt.push.service.HistoryService;
 import com.sopt.push.service.SlackAlertService;
+import com.sopt.push.service.SlackAlertService.ProcessingFailureAlert;
+import com.sopt.push.service.SlackAlertService.PushFailureAlert;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +51,8 @@ public class SqsHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
   @Override
   public SQSBatchResponse handleRequest(SQSEvent event, Context context) {
     List<SQSBatchResponse.BatchItemFailure> failures = new ArrayList<>();
+    List<PushFailureAlert> pushFailureAlerts = new ArrayList<>();
+    List<ProcessingFailureAlert> processingFailureAlerts = new ArrayList<>();
 
     if (event == null || event.getRecords() == null || event.getRecords().isEmpty()) {
       log.warn("SQS event is null or has no records");
@@ -59,32 +63,43 @@ public class SqsHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
 
     for (SQSEvent.SQSMessage record : event.getRecords()) {
       try {
-        processRecord(record);
+        ProcessingResult result = processRecord(record);
+        if (result.pushFailureAlert() != null) {
+          pushFailureAlerts.add(result.pushFailureAlert());
+        }
+        if (result.processingFailureAlert() != null) {
+          processingFailureAlerts.add(result.processingFailureAlert());
+        }
       } catch (Exception ex) {
         log.error("Failed to process SQS record. messageId={}", record.getMessageId(), ex);
-        slackAlertService.notifyProcessingFailure(record.getMessageId(), ex.getMessage());
+        processingFailureAlerts.add(
+            SlackAlertService.processingFailureAlert(record.getMessageId(), ex.getMessage()));
         failures.add(new SQSBatchResponse.BatchItemFailure(record.getMessageId()));
       }
     }
 
+    slackAlertService.notifyPushFailures(pushFailureAlerts);
+    slackAlertService.notifyProcessingFailures(processingFailureAlerts);
+
     return new SQSBatchResponse(failures);
   }
 
-  private void processRecord(SQSEvent.SQSMessage record) throws Exception {
+  private ProcessingResult processRecord(SQSEvent.SQSMessage record) throws Exception {
     FailureMessage failureMessage = extractFailureMessage(record);
     String token = failureMessage.token();
 
     if (token == null || token.isBlank()) {
-      slackAlertService.notifyProcessingFailure(record.getMessageId(), "Missing device token");
       log.warn("Push failure message has no token. sqsMessageId={}", record.getMessageId());
-      return;
+      return ProcessingResult.processingFailure(
+          SlackAlertService.processingFailureAlert(record.getMessageId(), "Missing device token"));
     }
 
     DeviceTokenEntity tokenEntity = deviceTokenService.findByDeviceToken(token).orElse(null);
     if (tokenEntity == null) {
       log.info("No token entity found for failed token. sqsMessageId={}", record.getMessageId());
-      slackAlertService.notifyPushFailure(null, token, failureMessage.messageId());
-      return;
+      createFailLog(null, failureMessage.messageId());
+      return ProcessingResult.pushFailure(
+          SlackAlertService.pushFailureAlert(null, token, failureMessage.messageId()));
     }
 
     UserTokenInfoDto userTokenInfoDto =
@@ -94,10 +109,11 @@ public class SqsHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
         userTokenInfoDto.userId(),
         failureMessage.messageId());
 
-    createFailLog(userTokenInfoDto.userId(), failureMessage.messageId());
     endpointFacade.clean(userTokenInfoDto);
-    slackAlertService.notifyPushFailure(
-        userTokenInfoDto.userId(), userTokenInfoDto.deviceToken(), failureMessage.messageId());
+    createFailLog(userTokenInfoDto.userId(), failureMessage.messageId());
+    return ProcessingResult.pushFailure(
+        SlackAlertService.pushFailureAlert(
+            userTokenInfoDto.userId(), userTokenInfoDto.deviceToken(), failureMessage.messageId()));
   }
 
   private FailureMessage extractFailureMessage(SQSEvent.SQSMessage record) throws Exception {
@@ -162,6 +178,34 @@ public class SqsHandler implements RequestHandler<SQSEvent, SQSBatchResponse> {
 
     private String messageId() {
       return messageId;
+    }
+  }
+
+  private static final class ProcessingResult {
+
+    private final PushFailureAlert pushFailureAlert;
+    private final ProcessingFailureAlert processingFailureAlert;
+
+    private ProcessingResult(
+        PushFailureAlert pushFailureAlert, ProcessingFailureAlert processingFailureAlert) {
+      this.pushFailureAlert = pushFailureAlert;
+      this.processingFailureAlert = processingFailureAlert;
+    }
+
+    private static ProcessingResult pushFailure(PushFailureAlert alert) {
+      return new ProcessingResult(alert, null);
+    }
+
+    private static ProcessingResult processingFailure(ProcessingFailureAlert alert) {
+      return new ProcessingResult(null, alert);
+    }
+
+    private PushFailureAlert pushFailureAlert() {
+      return pushFailureAlert;
+    }
+
+    private ProcessingFailureAlert processingFailureAlert() {
+      return processingFailureAlert;
     }
   }
 }

--- a/src/main/java/com/sopt/push/service/SlackAlertService.java
+++ b/src/main/java/com/sopt/push/service/SlackAlertService.java
@@ -1,0 +1,122 @@
+package com.sopt.push.service;
+
+import static com.sopt.push.common.Constants.HEADER_CONTENT_TYPE;
+import static com.sopt.push.common.Constants.HTTP_METHOD_POST;
+import static com.sopt.push.common.Constants.HTTP_REQUEST_TIMEOUT_SECONDS;
+import static com.sopt.push.common.Constants.MEDIA_TYPE_APPLICATION_JSON;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sopt.push.config.EnvConfig;
+import com.sopt.push.config.ObjectMapperConfig;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class SlackAlertService {
+
+  private final HttpClient httpClient;
+  private final ObjectMapper objectMapper;
+  private final String webhookUrl;
+
+  public SlackAlertService(HttpClient httpClient, EnvConfig envConfig) {
+    this.httpClient = httpClient;
+    this.objectMapper = ObjectMapperConfig.getObjectMapper();
+    this.webhookUrl = envConfig.getSlackFailureWebhookUrl();
+  }
+
+  public void notifyPushFailure(String userId, String deviceToken, String messageId) {
+    send(
+        "Push delivery failure",
+        "SNS reported a failed push delivery.",
+        Map.of(
+            "User ID", replaceNullValue(userId),
+            "Device Token", maskToken(deviceToken),
+            "Message ID", replaceNullValue(messageId),
+            "Detected At", Instant.now().toString()));
+  }
+
+  public void notifyProcessingFailure(String sqsMessageId, String reason) {
+    send(
+        "Push failure processing error",
+        "The failure handler could not process an SQS message.",
+        Map.of(
+            "SQS Message ID", replaceNullValue(sqsMessageId),
+            "Reason", replaceNullValue(reason),
+            "Detected At", Instant.now().toString()));
+  }
+
+  private void send(String title, String summary, Map<String, String> fields) {
+    if (webhookUrl == null) {
+      log.warn("Slack failure webhook URL is not configured. title={}", title);
+      return;
+    }
+
+    try {
+      String body = objectMapper.writeValueAsString(createPayload(title, summary, fields));
+      HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(webhookUrl))
+              .header(HEADER_CONTENT_TYPE, MEDIA_TYPE_APPLICATION_JSON)
+              .method(HTTP_METHOD_POST, HttpRequest.BodyPublishers.ofString(body))
+              .timeout(Duration.ofSeconds(HTTP_REQUEST_TIMEOUT_SECONDS))
+              .build();
+
+      HttpResponse<String> response =
+          httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() < 200 || response.statusCode() >= 300) {
+        log.warn("Slack failure webhook returned status={}", response.statusCode());
+      }
+    } catch (Exception e) {
+      log.warn("Failed to send Slack failure alert", e);
+    }
+  }
+
+  private Map<String, Object> createPayload(
+      String title, String summary, Map<String, String> fields) {
+    return Map.of(
+        "text",
+        title,
+        "blocks",
+        List.of(
+            Map.of(
+                "type",
+                "header",
+                "text",
+                Map.of("type", "plain_text", "text", title, "emoji", true)),
+            Map.of("type", "section", "text", Map.of("type", "mrkdwn", "text", summary)),
+            Map.of(
+                "type",
+                "section",
+                "fields",
+                fields.entrySet().stream()
+                    .map(
+                        entry ->
+                            Map.of(
+                                "type",
+                                "mrkdwn",
+                                "text",
+                                String.format("*%s*\n%s", entry.getKey(), entry.getValue())))
+                    .toList())));
+  }
+
+  private String replaceNullValue(String value) {
+    return value == null || value.isBlank() ? "-" : value;
+  }
+
+  private String maskToken(String token) {
+    if (token == null || token.isBlank()) {
+      return "-";
+    }
+
+    int visibleLength = Math.min(8, token.length());
+    return token.substring(0, visibleLength) + "...";
+  }
+}

--- a/src/main/java/com/sopt/push/service/SlackAlertService.java
+++ b/src/main/java/com/sopt/push/service/SlackAlertService.java
@@ -14,6 +14,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -31,35 +33,36 @@ public class SlackAlertService {
     this.webhookUrl = envConfig.getSlackFailureWebhookUrl();
   }
 
-  public void notifyPushFailure(String userId, String deviceToken, String messageId) {
+  public void notifyPushFailures(List<PushFailureAlert> alerts) {
+    if (alerts == null || alerts.isEmpty()) {
+      return;
+    }
+
     send(
         "Push delivery failure",
-        "SNS reported a failed push delivery.",
-        Map.of(
-            "User ID", replaceNullValue(userId),
-            "Device Token", maskToken(deviceToken),
-            "Message ID", replaceNullValue(messageId),
-            "Detected At", Instant.now().toString()));
+        String.format("SNS reported %d failed push delivery event(s).", alerts.size()),
+        alerts.stream().map(this::createPushFailureFields).toList());
   }
 
-  public void notifyProcessingFailure(String sqsMessageId, String reason) {
+  public void notifyProcessingFailures(List<ProcessingFailureAlert> alerts) {
+    if (alerts == null || alerts.isEmpty()) {
+      return;
+    }
+
     send(
         "Push failure processing error",
-        "The failure handler could not process an SQS message.",
-        Map.of(
-            "SQS Message ID", replaceNullValue(sqsMessageId),
-            "Reason", replaceNullValue(reason),
-            "Detected At", Instant.now().toString()));
+        String.format("The failure handler could not process %d SQS message(s).", alerts.size()),
+        alerts.stream().map(this::createProcessingFailureFields).toList());
   }
 
-  private void send(String title, String summary, Map<String, String> fields) {
+  private void send(String title, String summary, List<Map<String, String>> fieldGroups) {
     if (webhookUrl == null) {
       log.warn("Slack failure webhook URL is not configured. title={}", title);
       return;
     }
 
     try {
-      String body = objectMapper.writeValueAsString(createPayload(title, summary, fields));
+      String body = objectMapper.writeValueAsString(createPayload(title, summary, fieldGroups));
       HttpRequest request =
           HttpRequest.newBuilder()
               .uri(URI.create(webhookUrl))
@@ -80,31 +83,86 @@ public class SlackAlertService {
   }
 
   private Map<String, Object> createPayload(
-      String title, String summary, Map<String, String> fields) {
-    return Map.of(
-        "text",
-        title,
-        "blocks",
-        List.of(
-            Map.of(
-                "type",
-                "header",
-                "text",
-                Map.of("type", "plain_text", "text", title, "emoji", true)),
-            Map.of("type", "section", "text", Map.of("type", "mrkdwn", "text", summary)),
-            Map.of(
-                "type",
-                "section",
-                "fields",
-                fields.entrySet().stream()
-                    .map(
-                        entry ->
-                            Map.of(
-                                "type",
-                                "mrkdwn",
-                                "text",
-                                String.format("*%s*\n%s", entry.getKey(), entry.getValue())))
-                    .toList())));
+      String title, String summary, List<Map<String, String>> fieldGroups) {
+    List<Map<String, Object>> blocks = new ArrayList<>();
+    blocks.add(
+        Map.of(
+            "type", "header", "text", Map.of("type", "plain_text", "text", title, "emoji", true)));
+    blocks.add(Map.of("type", "section", "text", Map.of("type", "mrkdwn", "text", summary)));
+
+    for (Map<String, String> fields : fieldGroups) {
+      blocks.add(
+          Map.of(
+              "type",
+              "section",
+              "fields",
+              fields.entrySet().stream()
+                  .map(
+                      entry ->
+                          Map.of(
+                              "type",
+                              "mrkdwn",
+                              "text",
+                              String.format("*%s*\n%s", entry.getKey(), entry.getValue())))
+                  .toList()));
+    }
+
+    return Map.of("text", title, "blocks", blocks);
+  }
+
+  private Map<String, String> createPushFailureFields(PushFailureAlert alert) {
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("User ID", replaceNullValue(alert.userId));
+    fields.put("Device Token", maskToken(alert.deviceToken));
+    fields.put("Message ID", replaceNullValue(alert.messageId));
+    fields.put("Detected At", alert.detectedAt.toString());
+    return fields;
+  }
+
+  private Map<String, String> createProcessingFailureFields(ProcessingFailureAlert alert) {
+    Map<String, String> fields = new LinkedHashMap<>();
+    fields.put("SQS Message ID", replaceNullValue(alert.sqsMessageId));
+    fields.put("Reason", replaceNullValue(alert.reason));
+    fields.put("Detected At", alert.detectedAt.toString());
+    return fields;
+  }
+
+  public static PushFailureAlert pushFailureAlert(
+      String userId, String deviceToken, String messageId) {
+    return new PushFailureAlert(userId, deviceToken, messageId, Instant.now());
+  }
+
+  public static ProcessingFailureAlert processingFailureAlert(String sqsMessageId, String reason) {
+    return new ProcessingFailureAlert(sqsMessageId, reason, Instant.now());
+  }
+
+  public static final class PushFailureAlert {
+
+    private final String userId;
+    private final String deviceToken;
+    private final String messageId;
+    private final Instant detectedAt;
+
+    private PushFailureAlert(
+        String userId, String deviceToken, String messageId, Instant detectedAt) {
+      this.userId = userId;
+      this.deviceToken = deviceToken;
+      this.messageId = messageId;
+      this.detectedAt = detectedAt;
+    }
+  }
+
+  public static final class ProcessingFailureAlert {
+
+    private final String sqsMessageId;
+    private final String reason;
+    private final Instant detectedAt;
+
+    private ProcessingFailureAlert(String sqsMessageId, String reason, Instant detectedAt) {
+      this.sqsMessageId = sqsMessageId;
+      this.reason = reason;
+      this.detectedAt = detectedAt;
+    }
   }
 
   private String replaceNullValue(String value) {

--- a/template.yaml
+++ b/template.yaml
@@ -156,7 +156,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Sub "sopt-push-failure-queue-${Stage}"
-      VisibilityTimeout: 120
+      VisibilityTimeout: 360
       MessageRetentionPeriod: 1209600
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PushFailureDeadLetterQueue.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -30,6 +30,12 @@ Parameters:
   MakersOperationServerUrl:
     Type: String
 
+  SlackFailureWebhookUrl:
+    Type: String
+    NoEcho: true
+    Default: ""
+    Description: Slack incoming webhook URL for push failure alerts
+
 Globals:
   Function:
     Runtime: java21
@@ -46,6 +52,7 @@ Globals:
         ALL_TOPIC_ARN: !Ref AllTopicArn
         MAKERS_APP_SERVER_URL: !Ref MakersAppServerUrl
         MAKERS_OPERATION_SERVER_URL: !Ref MakersOperationServerUrl
+        SLACK_FAILURE_WEBHOOK_URL: !Ref SlackFailureWebhookUrl
 
 Resources:
 
@@ -122,6 +129,65 @@ Resources:
                   - logs:PutLogEvents
                 Resource: "arn:aws:logs:*:*:*"
 
+        - PolicyName: SQSAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - sqs:ReceiveMessage
+                  - sqs:DeleteMessage
+                  - sqs:GetQueueAttributes
+                  - sqs:ChangeMessageVisibility
+                Resource:
+                  - !GetAtt PushFailureQueue.Arn
+
+  #######################################################
+  # Push Failure Queue
+  #######################################################
+
+  PushFailureDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "sopt-push-failure-dlq-${Stage}"
+      MessageRetentionPeriod: 1209600
+
+  PushFailureQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "sopt-push-failure-queue-${Stage}"
+      VisibilityTimeout: 120
+      MessageRetentionPeriod: 1209600
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt PushFailureDeadLetterQueue.Arn
+        maxReceiveCount: 5
+
+  PushFailureQueuePolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - !Ref PushFailureQueue
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: sns.amazonaws.com
+            Action:
+              - sqs:SendMessage
+            Resource: !GetAtt PushFailureQueue.Arn
+            Condition:
+              ArnEquals:
+                aws:SourceArn: !Ref PushFailuresTopicArn
+
+  PushFailureSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref PushFailuresTopicArn
+      Protocol: sqs
+      Endpoint: !GetAtt PushFailureQueue.Arn
+      RawMessageDelivery: false
+
   #######################################################
   # Lambda Functions
   #######################################################
@@ -162,15 +228,18 @@ Resources:
   SnsHandlerFunction:
     Type: AWS::Serverless::Function
     Properties:
-      FunctionName: !Sub "sopt-push-notification-lambda-sns-${Stage}"
-      Handler: com.sopt.push.lambda.SnsHandler::handleRequest
+      FunctionName: !Sub "sopt-push-notification-lambda-sqs-${Stage}"
+      Handler: com.sopt.push.lambda.SqsHandler::handleRequest
       CodeUri: build/libs/app.jar
       Role: !GetAtt PushLambdaRole.Arn
       Events:
         PushFailureEvent:
-          Type: SNS
+          Type: SQS
           Properties:
-            Topic: !Ref PushFailuresTopicArn
+            Queue: !GetAtt PushFailureQueue.Arn
+            BatchSize: 10
+            FunctionResponseTypes:
+              - ReportBatchItemFailures
 
 Outputs:
   ApiUrl:


### PR DESCRIPTION
<!--
name: Makers Push Notification Feature PR template
about: 구현한 기능과 변경 사항에 대해 구체적으로 작성해주세요
title: '[FEAT/{#이슈번호}] 기능 내용'
labels: ''
assignees: ''
-->

<!--
- 리뷰어 추가했나요?
- 허가자 추가했나요?
- 라벨 추가했나요?
-->

## Related Issue 🚀
- closed #29

## Work Description ✏️
기존에 SNS를 통해 실패를 추적하는 구조였지만, record 처리 중 발생한 예외를 내부에서 catch하고 최종적으로 성공 응답을 반환하는 구조여서 개별 실패 이벤트 처리가 실패해도 SNS 입장에서는 Lambda 호출이 성공한 것으로 볼 수 있어, 재시도나 DLQ로 이어지지 않을 수 있었습니다.
따라서 실패 이벤트를 명시적으로 큐에 저장하고, 처리 실패한 메시지만 재시도/DLQ로 이동시키는 구조가 필요하다고 판단하여 SQS와 DLQ를 도입했습니다.

### 작업 내용
 - 푸시 실패 이벤트 처리 구조를 `SNS -> Lambda`에서 `SNS -> SQS -> Lambda`로 변경
  - 실패 이벤트용 SQS Queue와 DLQ 추가
  - SNS Failure Topic이 SQS Queue로 메시지를 전달하도록 subscription 및 queue policy 추가
  - SQS batch item failure 응답을 사용해 실패한 메시지만 재시도되도록 처리
  - 푸시 실패 및 실패 처리 오류를 Slack webhook으로 알림
  - 로컬 테스트용 SQS 이벤트 샘플 추가


### 기존 구조
```
SNS Push Failure Topic
        │
        ▼
SnsHandler Lambda
        │
        ├──▶ DynamoDB 실패 history 기록
        │
        ├──▶ DynamoDB token/user 삭제
        │
        ├──▶ SNS endpoint 삭제
        │
        └──▶ SNS topic unsubscribe
```

### 변경된 구조
```
SNS Push Failure Topic
         │
         ▼
SQS PushFailureQueue
         │
         ▼
   SqsHandler Lambda
         │
         ├──▶ DynamoDB 실패 history 기록
         ├──▶ Endpoint Cleanup
         └──▶ Slack 실패 알림
         │
         │ 처리 실패
         ▼
      SQS Retry
         │
         │ 반복 실패
         ▼
       SQS DLQ
```